### PR TITLE
Change choose_starting_point English text

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -529,7 +529,7 @@ en-GB:
         welcome_title: Welcome to the Open Food Network!
         welcome_text: You have successfully created a
         next_step: Next step
-        choose_starting_point: 'Choose your starting point:'
+        choose_starting_point: 'choose your package:'
     order_cycles:
       edit:
         advanced_settings: Advanced Settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -616,7 +616,7 @@ en:
         welcome_title: Welcome to the Open Food Network!
         welcome_text: You have successfully created a
         next_step: Next step
-        choose_starting_point: 'Choose your starting point:'
+        choose_starting_point: 'choose your package:'
     order_cycles:
       edit:
         advanced_settings: Advanced Settings

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -529,7 +529,7 @@ en_GB:
         welcome_title: Welcome to the Open Food Network!
         welcome_text: You have successfully created a
         next_step: Next step
-        choose_starting_point: 'Choose your starting point:'
+        choose_starting_point: 'choose your package:'
     order_cycles:
       edit:
         advanced_settings: Advanced Settings


### PR DESCRIPTION
#### What? Why?
We changed all text (in English) that read, “Choose your starting point” to “choose your package.”

Closes #1926 

This change was needed to increase consistency. Feedback from users indicated that there was confusion between terms like profile, type, and package. 

We ran into a challenge when handling this issue:
- We were unable to locate the issue in the interface of the application. However, we were able to find it and change the text in the codebase. We aren’t able to confirm the change in the user interface of the application without recreation steps.

- We had difficulty installing dependencies using rbenv. We found success using RVM. 

#### What should we test?
- Testing is needed to verify that the user interface of the application is displaying the desired text. 
